### PR TITLE
Reduce number of closures generated when using `GlobalGenerator`

### DIFF
--- a/gl_generator/generators/global_gen.rs
+++ b/gl_generator/generators/global_gen.rs
@@ -264,7 +264,7 @@ fn write_load_fn<W>(registry: &Registry, dest: &mut W) -> io::Result<()>
 
     for c in &registry.cmds {
         try!(writeln!(dest,
-                      "{cmd_name}::load_with(|s| loadfn(s));",
+                      "{cmd_name}::load_with(&mut loadfn);",
                       cmd_name = &c.proto.ident[..]));
     }
 


### PR DESCRIPTION
When using `GlobalGenerator` rustc currently generates a lot of duplicate code for the closures in `gl::load_with`.

This PR changes the generator, so that instead of generating a new closure for every `{cmd_name}::load_with` call, the `loadfn` closure is borrowed.

Looking at a macOS release build of `gl/examples/basic.rs`, the binary size is reduced from 983 KiB to 675 KiB. Compile time is also improved. The translation pass goes from 0.560 secs to 0.222 secs and the LLVM passes go from 5.923 secs to 4.265 secs.