### PR TITLE
gl_generator: update xml-rs to v7 and publish v0.5.6

### DIFF
--- a/gl_generator/Cargo.toml
+++ b/gl_generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gl_generator"
-version = "0.5.5"
+version = "0.5.6"
 authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>",
         "Corey Richardson",
         "Arseny Kapoulkine"
@@ -21,5 +21,5 @@ unstable_generator_utils = []
 
 [dependencies]
 khronos_api = { version = "1.0.1", path = "../khronos_api" }
-log = "0.3.5"
-xml-rs = "0.6.0"
+log = "0.3"
+xml-rs = "0.7"


### PR DESCRIPTION
Bumps bitflags to v1.

Edit: Looks like xml-rs is about to [drop bitflags](https://github.com/netvl/xml-rs/commit/bb39eee35b6a861d6a9c0a50dda6152a222e4a76), possibly undoing previous version break(?) Best not to merge yet.