### PR TITLE
Add a _priv field to the generated structs

### DIFF
--- a/gl_generator/generators/debug_struct_gen.rs
+++ b/gl_generator/generators/debug_struct_gen.rs
@@ -149,6 +149,7 @@ fn write_struct<W>(registry: &Registry, dest: &mut W) -> io::Result<()>
         }
         try!(writeln!(dest, "pub {name}: FnPtr,", name = cmd.proto.ident));
     }
+    try!(writeln!(dest, "_priv: ()"));
 
     writeln!(dest, "}}")
 }
@@ -202,6 +203,7 @@ fn write_impl<W>(registry: &Registry, dest: &mut W) -> io::Result<()>
             },
         ))
     }
+    try!(writeln!(dest, "_priv: ()"));
 
     try!(writeln!(dest,
                   "}}

--- a/gl_generator/generators/struct_gen.rs
+++ b/gl_generator/generators/struct_gen.rs
@@ -149,6 +149,7 @@ fn write_struct<W>(registry: &Registry, dest: &mut W) -> io::Result<()>
         }
         try!(writeln!(dest, "pub {name}: FnPtr,", name = cmd.proto.ident));
     }
+    try!(writeln!(dest, "_priv: ()"));
 
     writeln!(dest, "}}")
 }
@@ -202,6 +203,8 @@ fn write_impl<W>(registry: &Registry, dest: &mut W) -> io::Result<()>
             },
         ))
     }
+
+    try!(writeln!(dest, "_priv: ()"));
 
     try!(writeln!(dest,
                   "}}


### PR DESCRIPTION
This prevents manual construction and will allow changing the contents of the structs without breaking the api.