### PR TITLE
Bump major version of khronos_api

### DIFF
--- a/gl/Cargo.toml
+++ b/gl/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["api-bindings", "rendering::graphics-api"]
 keywords = ["gl", "egl", "opengl", "khronos"]
 
 [build-dependencies]
-gl_generator = { version = "0.6.0", path = "../gl_generator" }
+gl_generator = { version = "0.6.1", path = "../gl_generator" }
 
 [dev-dependencies]
 glutin = "0.10.0"

--- a/gl_generator/Cargo.toml
+++ b/gl_generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gl_generator"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>",
         "Corey Richardson",
         "Arseny Kapoulkine"
@@ -22,6 +22,6 @@ path = "lib.rs"
 unstable_generator_utils = []
 
 [dependencies]
-khronos_api = { version = "1.1.0", path = "../khronos_api" }
+khronos_api = { version = "2.0.0", path = "../khronos_api" }
 log = "0.3.5"
 xml-rs = "0.7.0"

--- a/khronos_api/Cargo.toml
+++ b/khronos_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "khronos_api"
-version = "1.1.0"
+version = "2.0.0"
 authors = [
   "Brendan Zabarauskas <bjzaba@yahoo.com.au>",
   "Corey Richardson",


### PR DESCRIPTION
Fixes #434.

This was ultimately caused by #426, which updated the khronos_api submodule checkouts. Future updates to khronos_api should probably be treated as major version bumps to avoid this kind of trouble.