### PR TITLE
EGL binding generation improvements

### DIFF
--- a/gl_generator/generators/mod.rs
+++ b/gl_generator/generators/mod.rs
@@ -65,12 +65,16 @@ pub fn gen_enum_item<W>(enm: &Enum, types_prefix: &str, dest: &mut W) -> io::Res
 pub fn gen_types<W>(api: Api, dest: &mut W) -> io::Result<()>
     where W: io::Write
 {
+    if let Api::Egl = api {
+        try!(writeln!(dest, "{}", include_str!("templates/types/egl.rs")));
+        return Ok(());
+    }
+
     try!(writeln!(dest, "{}", include_str!("templates/types/gl.rs")));
 
     match api {
         Api::Glx => try!(writeln!(dest, "{}", include_str!("templates/types/glx.rs"))),
         Api::Wgl => try!(writeln!(dest, "{}", include_str!("templates/types/wgl.rs"))),
-        Api::Egl => try!(writeln!(dest, "{}", include_str!("templates/types/egl.rs"))),
         _ => {}
     }
 

--- a/gl_generator/registry/parse.rs
+++ b/gl_generator/registry/parse.rs
@@ -1097,17 +1097,6 @@ mod tests {
         }
 
         #[test]
-        fn test_cast_egl() {
-            let e = parse::make_enum("FOO".to_string(),
-                                     None,
-                                     "EGL_CAST(EGLint,-1)".to_string(),
-                                     Some("BAR".to_string()));
-            assert_eq!(e.ident, "FOO");
-            assert_eq!((&*e.ty, &*e.value), ("EGLint", "-1"));
-            assert_eq!(e.alias, Some("BAR".to_string()));
-        }
-
-        #[test]
         fn test_no_type() {
             let e = parse::make_enum("FOO".to_string(),
                                      None,
@@ -1163,6 +1152,78 @@ mod tests {
         fn test_ident_false() {
             let e = parse::make_enum("FALSE".to_string(), None, String::new(), None);
             assert_eq!(e.ty, "GLboolean");
+        }
+    }
+
+    mod make_egl_enum {
+        use registry::parse;
+
+        #[test]
+        fn test_cast_egl() {
+            let e = parse::make_egl_enum("FOO".to_string(),
+                                     None,
+                                     "EGL_CAST(EGLint,-1)".to_string(),
+                                     Some("BAR".to_string()));
+            assert_eq!(e.ident, "FOO");
+            assert_eq!((&*e.ty, &*e.value), ("EGLint", "-1"));
+            assert_eq!(e.alias, Some("BAR".to_string()));
+        }
+
+        #[test]
+        fn test_ident_true() {
+            let e = parse::make_egl_enum("TRUE".to_string(), None, "1234".to_string(), None);
+            assert_eq!(e.ty, "EGLBoolean");
+        }
+
+        #[test]
+        fn test_ident_false() {
+            let e = parse::make_egl_enum("FALSE".to_string(), None, "1234".to_string(), None);
+            assert_eq!(e.ty, "EGLBoolean");
+        }
+
+        #[test]
+        fn test_ull() {
+            let e = parse::make_egl_enum("FOO".to_string(),
+                                     Some("ull".to_string()),
+                                     "1234".to_string(),
+                                     None);
+            assert_eq!(e.ty, "EGLuint64KHR");
+        }
+
+        #[test]
+        fn test_negative_value() {
+            let e = parse::make_egl_enum("FOO".to_string(),
+                                     None,
+                                     "-1".to_string(),
+                                     None);
+            assert_eq!(e.ty, "EGLint");
+        }
+
+        #[test]
+        #[should_panic]
+        fn test_unknown_type() {
+            parse::make_egl_enum("FOO".to_string(),
+                             Some("blargh".to_string()),
+                             String::new(),
+                             None);
+        }
+
+        #[test]
+        #[should_panic]
+        fn test_unknown_value() {
+            parse::make_egl_enum("FOO".to_string(),
+                             None,
+                             "a".to_string(),
+                             None);
+        }
+
+        #[test]
+        #[should_panic]
+        fn test_empty_value() {
+            parse::make_egl_enum("FOO".to_string(),
+                             None,
+                             String::new(),
+                             None);
         }
     }
 

--- a/gl_generator/registry/parse.rs
+++ b/gl_generator/registry/parse.rs
@@ -155,18 +155,6 @@ fn make_enum(ident: String, ty: Option<String>, value: String, alias: Option<Str
             } else {
                 panic!("Unexpected value format: {}", value)
             }
-        } else if value.starts_with("EGL_CAST(") && value.ends_with(")") {
-            // Handling "SpecialNumbers" in the egl.xml file
-            // The values for these enums has the form `'EGL_CAST(' type ',' expr ')'`.
-            let working = &value[9..value.len() - 1];
-            if let Some((i, _)) = working.match_indices(",").next() {
-                let ty = working[..i].to_string();
-                let value = working[i + 1..].to_string();
-
-                (Cow::Owned(ty), value, true)
-            } else {
-                panic!("Unexpected value format: {}", value)
-            }
         } else {
             let ty = match ty {
                 Some(ref ty) if ty == "u" => "GLuint",


### PR DESCRIPTION
Hi! I noticed that in the generated EGL bindings the `TRUE` and `FALSE` constants have wrong type `GLboolean` (c_uchar) instead of `EGLBoolean` (c_uint) and other constants' types were `GLenum`. When fixing those issues I also noticed that constant `NO_NATIVE_FENCE_FD_ANDROID` won't compile (its a negative number), so I added fix for that as well.

### Summary
* Add separate function for EGL enum generation.
    * Support negative numbers in EGL enums.
    * Generated constants' types are EGL types.

### Breaking changes
* Changed `TRUE` and `FALSE` constants' types from GLboolean (c_uchar) to EGLBoolean (c_uint) in EGL bindings.
* Removed OpenGL types from EGL bindings, because OpenGL types are not used in EGL bindings anymore.