### PR TITLE
bump log -> 0.4.1

### DIFF
--- a/gl_generator/Cargo.toml
+++ b/gl_generator/Cargo.toml
@@ -24,5 +24,5 @@ unstable_generator_utils = []
 
 [dependencies]
 khronos_api = { version = "2.0.0", path = "../khronos_api" }
-log = "0.3.5"
+log = "0.4.1"
 xml-rs = "0.7.0"


### PR DESCRIPTION
Bump log dependency version 0.3.5 -> 0.4.1 in gl_generator.