### PR TITLE
webgl_generator: fix get_extension

### DIFF
--- a/webgl_generator/webgl_generators/stdweb_gen.rs
+++ b/webgl_generator/webgl_generators/stdweb_gen.rs
@@ -739,7 +739,7 @@ where
         r#"
 
     pub fn get_extension<E: Extension>(&self) -> Option<E> {{
-        (js! {{ return @{{self}}.getExtension({{E::NAME}}); }} ).try_into().ok()
+        (js! {{ return @{{self}}.getExtension(@{{E::NAME}}); }} ).try_into().ok()
     }}"#
     )
 }


### PR DESCRIPTION
There was a missing @ that resulted in JavaScript syntax error if you try to use the method.

Although I've fixed the SyntaxError, method doesn't actually work anyway, it just always returns `None`

I've looked into it, and the reason is that checking `intstanceof` while converting from `Reference` to some concrete type, e. g `ANGLE_instanced_arrays` fails. That I don't know how to fix, since I don't understand how to check it in JavaScript. You can't write `ext instanceof ANGLE_instanced_arrays` because it is not present in global scope I guess.

I can only think of a hacky solution like specifying `#[reference(instance_of = "Object")]`.