### PR TITLE
Bump version of stdweb-derive

### DIFF
--- a/tests/test_webgl_stdweb/Cargo.toml
+++ b/tests/test_webgl_stdweb/Cargo.toml
@@ -9,7 +9,7 @@ path = "lib.rs"
 
 [dependencies]
 stdweb = "0.4.0"
-stdweb-derive = "0.4.0"
+stdweb-derive = "0.5.0"
 serde = "1.0.0"
 serde_derive = "1.0.0"
 

--- a/webgl_stdweb/Cargo.toml
+++ b/webgl_stdweb/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["webgl", "stdweb"]
 webgl_generator = { version = "0.1.0", path = "../webgl_generator" }
 
 [dependencies]
-stdweb-derive = "0.4.0"
+stdweb-derive = "0.5.0"
 stdweb = "0.4.0"
 serde = "1.0.0"
 serde_derive = "1.0.0"


### PR DESCRIPTION
The latest version of stdweb (`0.4.9`) requires stdweb-derive `0.5.0` or it creates build errors.