### PR TITLE
Add enum groups to registry

### DIFF
--- a/gl_generator/registry/mod.rs
+++ b/gl_generator/registry/mod.rs
@@ -83,6 +83,14 @@ impl Hash for Enum {
 pub struct Binding {
     pub ident: String,
     pub ty: Cow<'static, str>,
+    pub group: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Group {
+    pub ident: String,
+    pub enums_type: Option<String>,
+    pub enums: Vec<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -112,6 +120,7 @@ pub struct Registry {
     pub enums: BTreeSet<Enum>,
     pub cmds: BTreeSet<Cmd>,
     pub aliases: BTreeMap<String, Vec<String>>,
+    pub groups: BTreeMap<String, Group>,
 }
 
 impl Registry {

--- a/gl_generator/registry/parse.rs
+++ b/gl_generator/registry/parse.rs
@@ -22,7 +22,7 @@ use xml::attribute::OwnedAttribute;
 use xml::reader::XmlEvent;
 use xml::EventReader as XmlEventReader;
 
-use registry::{Binding, Cmd, Enum, GlxOpcode, Registry};
+use registry::{Binding, Cmd, Enum, GlxOpcode, Group, Registry};
 use {Api, Fallbacks, Profile};
 
 pub fn from_xml<R: io::Read>(src: R, filter: Filter) -> Registry {
@@ -295,6 +295,7 @@ trait Parse: Sized + Iterator<Item = ParseEvent> {
         let mut features = Vec::new();
         let mut extensions = Vec::new();
         let mut aliases = BTreeMap::new();
+        let mut groups: BTreeMap<String, Group> = BTreeMap::new();
 
         while let Some(event) = self.next() {
             match event {
@@ -302,11 +303,20 @@ trait Parse: Sized + Iterator<Item = ParseEvent> {
                 ParseEvent::Text(_) => (),
                 ParseEvent::Start(ref name, _) if name == "comment" => self.skip_to_end("comment"),
                 ParseEvent::Start(ref name, _) if name == "types" => self.skip_to_end("types"),
-                ParseEvent::Start(ref name, _) if name == "groups" => self.skip_to_end("groups"),
+
+                // add group namespace
+                ParseEvent::Start(ref name, _) if name == "groups" => {
+                    groups.extend(self.consume_groups(filter.api));
+                },
 
                 // add enum namespace
-                ParseEvent::Start(ref name, _) if name == "enums" => {
+                ParseEvent::Start(ref name, ref attributes) if name == "enums" => {
                     enums.extend(self.consume_enums(filter.api));
+                    let enums_group = get_attribute(&attributes, "group");
+                    let enums_type = get_attribute(&attributes, "type");
+                    if let Some(group) = enums_group.and_then(|name| groups.get_mut(&name)) {
+                        group.enums_type = enums_type;
+                    }
                 },
 
                 // add command namespace
@@ -412,6 +422,7 @@ trait Parse: Sized + Iterator<Item = ParseEvent> {
             } else {
                 aliases
             },
+            groups,
         }
     }
 
@@ -541,6 +552,42 @@ trait Parse: Sized + Iterator<Item = ParseEvent> {
         }
     }
 
+    fn consume_groups(&mut self, api: Api) -> BTreeMap<String, Group> {
+        let mut groups = BTreeMap::new();
+        loop {
+            match self.next().unwrap() {
+                ParseEvent::Start(ref name, ref attributes) if name == "group" => {
+                    let ident = get_attribute(&attributes, "name").unwrap();
+                    let group = Group {
+                        ident: ident.clone(),
+                        enums_type: None,
+                        enums: self.consume_group_enums(api)
+                    };
+                    groups.insert(ident, group);
+                },
+                ParseEvent::End(ref name) if name == "groups" => break,
+                event => panic!("Expected </groups>, found: {:?}", event),
+            }
+        }
+        groups
+    }
+
+    fn consume_group_enums(&mut self, api: Api) -> Vec<String> {
+        let mut enums = Vec::new();
+        loop {
+            match self.next().unwrap() {
+                ParseEvent::Start(ref name, ref attributes) if name == "enum" => {
+                    let enum_name = get_attribute(&attributes, "name");
+                    enums.push(trim_enum_prefix(&enum_name.unwrap(), api));
+                    self.consume_end_element("enum");
+                },
+                ParseEvent::End(ref name) if name == "group" => break,
+                event => panic!("Expected </group>, found: {:?}", event),
+            }
+        }
+        enums
+    }
+
     fn consume_cmds(&mut self, api: Api) -> (Vec<Cmd>, BTreeMap<String, Vec<String>>) {
         let mut cmds = Vec::new();
         let mut aliases: BTreeMap<String, Vec<String>> = BTreeMap::new();
@@ -573,7 +620,7 @@ trait Parse: Sized + Iterator<Item = ParseEvent> {
     fn consume_cmd(&mut self, api: Api) -> Cmd {
         // consume command prototype
         self.consume_start_element("proto");
-        let mut proto = self.consume_binding("proto");
+        let mut proto = self.consume_binding("proto", &[]);
         proto.ident = trim_cmd_prefix(&proto.ident, api).to_string();
 
         let mut params = Vec::new();
@@ -582,8 +629,8 @@ trait Parse: Sized + Iterator<Item = ParseEvent> {
         let mut glx = None;
         loop {
             match self.next().unwrap() {
-                ParseEvent::Start(ref name, _) if name == "param" => {
-                    params.push(self.consume_binding("param"));
+                ParseEvent::Start(ref name, ref attributes) if name == "param" => {
+                    params.push(self.consume_binding("param", attributes));
                 },
                 ParseEvent::Start(ref name, ref attributes) if name == "alias" => {
                     alias = get_attribute(&attributes, "name");
@@ -615,7 +662,7 @@ trait Parse: Sized + Iterator<Item = ParseEvent> {
         }
     }
 
-    fn consume_binding(&mut self, outside_tag: &str) -> Binding {
+    fn consume_binding(&mut self, outside_tag: &str, attributes: &[Attribute]) -> Binding {
         // consume type
         let mut ty = String::new();
         loop {
@@ -644,6 +691,7 @@ trait Parse: Sized + Iterator<Item = ParseEvent> {
         Binding {
             ident: ident,
             ty: to_rust_ty(ty),
+            group: get_attribute(&attributes, "group"),
         }
     }
 }


### PR DESCRIPTION
Update the registry to include enum group information and the group names in parameter bindings. 

Note that this PR does not change the existing generators, but enables custom generator to create strongly typed enums. 

E.g. something like: 

````rust
gl::PolygonMode(MaterialFace::FRONT, PolygonMode::FILL);
````

from:

```
<group name="PolygonMode">
    <enum name="GL_FILL"/>
    <enum name="GL_LINE"/>
    <enum name="GL_POINT"/>
</group>
```

```
<group name="MaterialFace">
    <enum name="GL_BACK"/>
    <enum name="GL_FRONT"/>
    <enum name="GL_FRONT_AND_BACK"/>
</group>
```

```
<command>
    <proto>void <name>glPolygonMode</name></proto>
    <param group="MaterialFace"><ptype>GLenum</ptype> <name>face</name></param>
    <param group="PolygonMode"><ptype>GLenum</ptype> <name>mode</name></param>
    <glx type="render" opcode="101"/>
</command>
```