### PR TITLE
Fix missing dyn warning

### DIFF
--- a/gl_generator/generators/debug_struct_gen.rs
+++ b/gl_generator/generators/debug_struct_gen.rs
@@ -187,7 +187,7 @@ where
             #[allow(dead_code, unused_variables)]
             pub fn load_with<F>(mut loadfn: F) -> {api} where F: FnMut(&'static str) -> *const __gl_imports::raw::c_void {{
                 #[inline(never)]
-                fn do_metaloadfn(loadfn: &mut FnMut(&'static str) -> *const __gl_imports::raw::c_void,
+                fn do_metaloadfn(loadfn: &mut dyn FnMut(&'static str) -> *const __gl_imports::raw::c_void,
                                  symbol: &'static str,
                                  symbols: &[&'static str])
                                  -> *const __gl_imports::raw::c_void {{

--- a/gl_generator/generators/global_gen.rs
+++ b/gl_generator/generators/global_gen.rs
@@ -63,7 +63,7 @@ where
         dest,
         r#"
         #[inline(never)]
-        fn metaloadfn(loadfn: &mut FnMut(&'static str) -> *const __gl_imports::raw::c_void,
+        fn metaloadfn(loadfn: &mut dyn FnMut(&'static str) -> *const __gl_imports::raw::c_void,
                       symbol: &'static str,
                       fallbacks: &[&'static str]) -> *const __gl_imports::raw::c_void {{
             let mut ptr = loadfn(symbol);

--- a/gl_generator/generators/struct_gen.rs
+++ b/gl_generator/generators/struct_gen.rs
@@ -187,7 +187,7 @@ where
             #[allow(dead_code, unused_variables)]
             pub fn load_with<F>(mut loadfn: F) -> {api} where F: FnMut(&'static str) -> *const __gl_imports::raw::c_void {{
                 #[inline(never)]
-                fn do_metaloadfn(loadfn: &mut FnMut(&'static str) -> *const __gl_imports::raw::c_void,
+                fn do_metaloadfn(loadfn: &mut dyn FnMut(&'static str) -> *const __gl_imports::raw::c_void,
                                  symbol: &'static str,
                                  symbols: &[&'static str])
                                  -> *const __gl_imports::raw::c_void {{


### PR DESCRIPTION
The latest Rust nightly will print a warning when the `dyn` keyword is
not present. This adds the keyword to prevent the warning from popping
up downstream.

An alternative would be to add an annotation to ignore the warning,
which would support more outdated Rust versions, however all recent Rust
versions should support the `dyn` keyword.