### PR TITLE
Improve compile times by avoiding inlining

### DIFF
--- a/gl_generator/generators/global_gen.rs
+++ b/gl_generator/generators/global_gen.rs
@@ -285,12 +285,14 @@ where
         /// ~~~
         #[allow(dead_code)]
         pub fn load_with<F>(mut loadfn: F) where F: FnMut(&'static str) -> *const __gl_imports::raw::c_void {{
+            #[inline(never)]
+            fn inner(loadfn: &mut dyn FnMut(&'static str) -> *const __gl_imports::raw::c_void) {{
     "));
 
     for c in &registry.cmds {
         try!(writeln!(
             dest,
-            "{cmd_name}::load_with(&mut loadfn);",
+            "{cmd_name}::load_with(&mut *loadfn);",
             cmd_name = &c.proto.ident[..]
         ));
     }
@@ -298,6 +300,9 @@ where
     writeln!(
         dest,
         "
+            }}
+
+            inner(&mut loadfn)
         }}
     "
     )

--- a/gl_generator/registry/parse.rs
+++ b/gl_generator/registry/parse.rs
@@ -201,7 +201,7 @@ fn make_egl_enum(ident: String, ty: Option<String>, value: String, alias: Option
             }
         } else {
             match value.chars().next() {
-                Some('-') | Some('0'...'9') => (),
+                Some('-') | Some('0'..='9') => (),
                 _ => panic!("Unexpected value format: {}", value),
             }
 


### PR DESCRIPTION
As discussed in #313, this change improves build times. I used the `simple` example, but made a copy of it such that it's `target` folder is independent of the one of this workspace. I then tested two kinds of changes: (a) just `touch main.rs` without changing anything and (b) change the name of the closure in `gl::load_with` to something else.

- `touch main.rs` rebuild: 
    - before: 3.9s
    - after: 2.45s
    - without `gl::load_with`: 2.4s (this line completely removed as a baseline; of course running the program would panic)
- change name of `symbol` in `load_with` closure (different number of chars):
    - before: 10.7s
    - after: 3.0s

So overall pretty nice wins I would say. Keep in mind though that these are no scientific benchmarks. I just repeated each "test" three times and calculated the approximate average in my head :grin: 

I guess one could optimize further by changing the public API. But this seems fine already and is not a breaking change. And by the way, as far as I can tell, the other generators do not have this problems or have this problem already fixed.

(And I hope it's OK to sneak the warning fix commit into this PR)
