### PR TITLE
Add license symlink

### DIFF
--- a/gl/LICENSE
+++ b/gl/LICENSE
@@ -1,0 +1,1 @@
+LICENSE

--- a/gl_generator/LICENSE
+++ b/gl_generator/LICENSE
@@ -1,0 +1,1 @@
+LICENSE

--- a/khronos_api/LICENSE
+++ b/khronos_api/LICENSE
@@ -1,0 +1,1 @@
+LICENSE

--- a/webgl_generator/LICENSE
+++ b/webgl_generator/LICENSE
@@ -1,0 +1,1 @@
+LICENSE

--- a/webgl_stdweb/LICENSE
+++ b/webgl_stdweb/LICENSE
@@ -1,0 +1,1 @@
+LICENSE


### PR DESCRIPTION
To make it easier for Linux distributions to ship the licenses text within the crates' directory.