### PR TITLE
Replace '_priv: ()' with '#[non_exhaustive]'.

### DIFF
--- a/gl_generator/generators/debug_struct_gen.rs
+++ b/gl_generator/generators/debug_struct_gen.rs
@@ -156,6 +156,7 @@ where
         "
         #[allow(non_camel_case_types, non_snake_case, dead_code)]
         #[derive(Clone)]
+        #[non_exhaustive]
         pub struct {api} {{",
         api = super::gen_struct_name(registry.api)
     )?;
@@ -166,7 +167,6 @@ where
         }
         writeln!(dest, "pub {name}: FnPtr,", name = cmd.proto.ident)?;
     }
-    writeln!(dest, "_priv: ()")?;
 
     writeln!(dest, "}}")
 }
@@ -222,7 +222,6 @@ where
             },
         )?
     }
-    writeln!(dest, "_priv: ()")?;
 
     writeln!(
         dest,

--- a/gl_generator/generators/struct_gen.rs
+++ b/gl_generator/generators/struct_gen.rs
@@ -156,6 +156,7 @@ where
         "
         #[allow(non_camel_case_types, non_snake_case, dead_code)]
         #[derive(Clone)]
+        #[non_exhaustive]
         pub struct {api} {{",
         api = super::gen_struct_name(registry.api)
     )?;
@@ -166,7 +167,6 @@ where
         }
         writeln!(dest, "pub {name}: FnPtr,", name = cmd.proto.ident)?;
     }
-    writeln!(dest, "_priv: ()")?;
 
     writeln!(dest, "}}")
 }
@@ -222,8 +222,6 @@ where
             },
         )?
     }
-
-    writeln!(dest, "_priv: ()")?;
 
     writeln!(
         dest,


### PR DESCRIPTION
Since [Rust 1.40](https://blog.rust-lang.org/2019/12/19/Rust-1.40.0.html#non_exhaustive-structs-enums-and-variants) `non_exhaustive` is stable, which is preferred over `_priv`, see also https://rust-lang.github.io/rust-clippy/master/#manual_non_exhaustive.

This PR adapts everything to the latest recommended way.