### PR TITLE
Add wasm-bindgen as an optional dependency to webgl_stdweb

### DIFF
--- a/webgl_stdweb/Cargo.toml
+++ b/webgl_stdweb/Cargo.toml
@@ -22,3 +22,4 @@ stdweb-derive = "0.5"
 stdweb = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
+wasm-bindgen = { version = "0.2", optional = true }


### PR DESCRIPTION
This allows webgl_stdweb to be compiled under wasm-pack, as it allows the `js!`/`derive(ReferenceType)` stdweb macros to access any `wasm_bindgen::` functions/macros it may need.

Closes #506, sort of?